### PR TITLE
Edit tonne_freight alias (was re-defining another pint unit)

### DIFF
--- a/checks.csv
+++ b/checks.csv
@@ -10,3 +10,4 @@
 toe,  [energy],
 tce,  [energy], *
 GW a, [energy],
+kWa,  [energy], *

--- a/definitions.txt
+++ b/definitions.txt
@@ -8,6 +8,9 @@
 
 tonne_of_coal_equivalent = 29.308 GJ = tce
 
+# Watt-annual
+watt_annual = watt * year = Wa = wattannual
+
 
 # Currency
 

--- a/definitions.txt
+++ b/definitions.txt
@@ -27,7 +27,7 @@ USD_2005 = 1.2435 * EUR_2005 = USD = $_2005
 
 vehicle = [vehicle] = v
 passenger = [passenger] = p = pass
-tonne_freight = [tonne_freight] = tf = tonnef
+tonne_freight = [tonne_freight] = tfr = tonnef
 vkm = vehicle * kilometer
 pkm = passenger * kilometer
 tkm = tonne_freight * kilometer

--- a/definitions.txt
+++ b/definitions.txt
@@ -8,8 +8,8 @@
 
 tonne_of_coal_equivalent = 29.308 GJ = tce
 
-# Watt-annual
-watt_annual = watt * year = Wa = wattannual
+# Watt-annum
+Wa = watt * year
 
 
 # Currency


### PR DESCRIPTION
Minor fix to deal with a conflict with one of the aliases of the `tonne_freight` commodity.

The alias, which is `tf`, was already used in `Pint`'s default unit registry (`default_en.txt`) as an alias for another unit.

Therefore I suggest to change it to tfr or to just delete it (as suggested by Paul)