### PR TITLE
Fixed annual average conversion between EUR and USD

### DIFF
--- a/definitions.txt
+++ b/definitions.txt
@@ -23,7 +23,7 @@ EUR_2000 = 0.94662 * EUR_2005 = €_2000
 # Exchange rate EUR/USD in 2005, data from
 # https://www.statista.com/statistics/412794/euro-to-u-s-dollar-annual-average-exchange-rate/
 
-USD_2005 = 1.2435 * EUR_2005 = USD = $_2005
+USD_2005 = 0.80418 * EUR_2005 = USD = $_2005
 
 
 # Transportation activity


### PR DESCRIPTION
This PR addresses an error in the 2005 average annual conversion between USD and EUR.

Instead of being 1 USD_2005 = 1.24 EUR_2005, it should be the other way around.